### PR TITLE
Country selector

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
-#github "xmartlabs/Eureka" ~> 4.0
-github "Mandelkind/Eureka" "SplitRow"
+github "xmartlabs/Eureka" "master" 

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "xmartlabs/Eureka" ~> 4.0
+#github "xmartlabs/Eureka" ~> 4.0
+github "Mandelkind/Eureka" "SplitRow"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Mandelkind/Eureka" "be4c01d20b1bcfcaf990baae092d75ff2bfe07b2"
+github "xmartlabs/Eureka" "a9552a715293c4fc70e26177533461b0e8e7b572"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "xmartlabs/Eureka" "4.0.1"
+github "Mandelkind/Eureka" "be4c01d20b1bcfcaf990baae092d75ff2bfe07b2"

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="adJ-sV-KLQ">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,13 +18,31 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
+                    <navigationItem key="navigationItem" id="1SO-x1-pZA"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="436" y="133"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="UKt-41-Uco">
+            <objects>
+                <navigationController id="adJ-sV-KLQ" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="kFj-ka-BXA">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="Nid-qn-PBg"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="g8s-cj-0AQ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-503" y="133"/>
         </scene>
     </scenes>
 </document>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -21,16 +21,33 @@ class ViewController: FormViewController {
                 $0.countryPlaceholder = "Country"
                 $0.postalCodePlaceholder = "Zip code"
         }
-            +++ Section()
-                <<< MyPostalAddressRow() {
-                    $0.streetPlaceholder = "Street"
-                    $0.cityPlaceholder = "City"
-                    $0.postalCodePlaceholder = "Zip code"
-                }.cellSetup({ (cell, row) in
-                    cell.streetTextField?.font = .systemFont(ofSize: 18)
-                    cell.postalCodeTextField?.font = .systemFont(ofSize: 18)
-                    cell.cityTextField?.font = .systemFont(ofSize: 18)
-                })
+			
+		+++ Section()
+			<<< PostalAddressRow() {
+				$0.streetPlaceholder = "Street"
+				$0.statePlaceholder = "State"
+				$0.cityPlaceholder = "City"
+				$0.countryPlaceholder = "Country"
+				$0.postalCodePlaceholder = "Zip code"
+				
+				$0.countrySelectorRow = PushRow<String>(){
+					$0.options = ["GB","US"]
+					$0.displayValueFor = { guard let isoCode = $0 else{ return nil }
+						return Locale.current.localizedString(forRegionCode: isoCode)
+					}
+				}
+			}
+			
+		+++ Section()
+			<<< MyPostalAddressRow() {
+                $0.streetPlaceholder = "Street"
+				$0.cityPlaceholder = "City"
+				$0.postalCodePlaceholder = "Zip code"
+			}.cellSetup({ (cell, row) in
+				cell.streetTextField?.font = .systemFont(ofSize: 18)
+				cell.postalCodeTextField?.font = .systemFont(ofSize: 18)
+				cell.cityTextField?.font = .systemFont(ofSize: 18)
+			})
     }
 }
 

--- a/Sources/PostalAddressCell.swift
+++ b/Sources/PostalAddressCell.swift
@@ -20,10 +20,11 @@ public protocol PostalAddressCellConformance {
     var postalCodeTextField: UITextField? { get }
     var cityTextField: UITextField? { get }
     var countryTextField: UITextField? { get }
+	var countrySelectorTableView: UITableView?{ get }
 }
 
 /// Base class that implements the cell logic for the PostalAddressRow
-open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAddressCellConformance, UITextFieldDelegate {
+open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAddressCellConformance, UITextFieldDelegate, UITableViewDelegate, UITableViewDataSource {
 
     @IBOutlet open var streetTextField: UITextField?
     @IBOutlet open var firstSeparatorView: UIView?
@@ -32,10 +33,14 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
     @IBOutlet open var cityTextField: UITextField?
     @IBOutlet open var secondSeparatorView: UIView?
     @IBOutlet open var countryTextField: UITextField?
-
+	@IBOutlet open var countrySelectorTableView: UITableView?
+	
     @IBOutlet weak var postalPercentageConstraint: NSLayoutConstraint?
-
+	
     open var textFieldOrdering: [UITextField?] = []
+	var textFieldOrderingVisible: [UITextField?]{
+		return textFieldOrdering.filter{ $0?.isHidden == false }
+	}
 
     public required init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -61,6 +66,8 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
         cityTextField?.removeTarget(self, action: nil, for: .allEvents)
         countryTextField?.delegate = nil
         countryTextField?.removeTarget(self, action: nil, for: .allEvents)
+		countrySelectorTableView?.delegate = nil
+		countrySelectorTableView?.dataSource = nil
         imageView?.removeObserver(self, forKeyPath: "image")
     }
 
@@ -80,6 +87,48 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
             textField?.delegate = self
             textField?.font = .preferredFont(forTextStyle: UIFontTextStyle.body)
         }
+		
+		if (row as? PostalAddressRowConformance)?.countrySelectorRow == nil{
+			countrySelectorTableView?.isHidden = true
+			countryTextField?.isHidden = false
+		} else {
+			countrySelectorTableView?.isHidden = false
+			countryTextField?.isHidden = true
+		}
+		
+		countrySelectorTableView?.isScrollEnabled = false
+		countrySelectorTableView?.sectionHeaderHeight = 0.0
+		countrySelectorTableView?.sectionFooterHeight = 0.0
+		countrySelectorTableView?.delegate = self
+		countrySelectorTableView?.dataSource = self
+		
+		if let rowConformance = row as? PostalAddressRowConformance, let selectorRow = rowConformance.countrySelectorRow{
+			selectorRow
+				.onChange{ [weak self] in
+					guard let this = self else{ return }
+					
+					if this.row.baseValue == nil{
+						this.row.baseValue = PostalAddress()
+					}
+					
+					this.row.value?.country = $0.value
+					$0.title = $0.displayValueFor?($0.value) ?? $0.noValueDisplayText ?? (this.row as? PostalAddressRowConformance)?.countryPlaceholder
+					
+					this.row.updateCell()
+					
+				}.cellSetup{ [weak self] cell, row in
+					cell.selectionStyle = .none
+					cell.detailTextLabel?.isHidden = true
+					cell.textLabel?.textColor = self?.row.value?.country == nil ? .lightGray : (self?.row.isDisabled == true ? .gray : .black)
+					
+				}.cellUpdate{ [weak self] cell, row in
+					cell.selectionStyle = .none
+					cell.textLabel?.textColor = self?.row.value?.country == nil ? .lightGray : (self?.row.isDisabled == true ? .gray : .black)
+				}
+			
+			selectorRow.baseCell.setup()
+		}
+		
 
         for separator in [firstSeparatorView, secondSeparatorView] {
             separator?.backgroundColor = .gray
@@ -118,6 +167,9 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
             setPlaceholderToTextField(textField: postalCodeTextField, placeholder: rowConformance.postalCodePlaceholder)
             setPlaceholderToTextField(textField: cityTextField, placeholder: rowConformance.cityPlaceholder)
             setPlaceholderToTextField(textField: countryTextField, placeholder: rowConformance.countryPlaceholder)
+			
+			rowConformance.countrySelectorRow?.title = rowConformance.countrySelectorRow?.title ?? rowConformance.countryPlaceholder
+			rowConformance.countrySelectorRow?.selectorTitle = rowConformance.countrySelectorRow?.selectorTitle ?? rowConformance.countryPlaceholder
         }
     }
 
@@ -137,12 +189,13 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
                 stateTextField?.canBecomeFirstResponder == true ||
                 postalCodeTextField?.canBecomeFirstResponder == true ||
                 cityTextField?.canBecomeFirstResponder == true ||
-                countryTextField?.canBecomeFirstResponder == true
+                countryTextField?.canBecomeFirstResponder == true ||
+				(row as? PostalAddressRowConformance)?.countrySelectorRow?.cell?.cellCanBecomeFirstResponder() == true
         )
     }
 
     open override func cellBecomeFirstResponder(withDirection direction: Direction) -> Bool {
-        return direction == .down ? textFieldOrdering.first??.becomeFirstResponder() ?? false : textFieldOrdering.last??.becomeFirstResponder() ?? false
+        return direction == .down ? textFieldOrderingVisible.first??.becomeFirstResponder() ?? false : textFieldOrderingVisible.last??.becomeFirstResponder() ?? false
     }
 
     open override func cellResignFirstResponder() -> Bool {
@@ -152,11 +205,12 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
             && stateTextField?.resignFirstResponder() ?? true
             && cityTextField?.resignFirstResponder() ?? true
             && countryTextField?.resignFirstResponder() ?? true
+			&& (row as? PostalAddressRowConformance)?.countrySelectorRow?.cell?.cellResignFirstResponder() ?? true
     }
 
     override open var inputAccessoryView: UIView? {
         if let v = formViewController()?.inputAccessoryView(for: row) as? NavigationAccessoryView {
-            guard let first = textFieldOrdering.first, let last = textFieldOrdering.last, first != last else { return v }
+            guard let first = textFieldOrderingVisible.first, let last = textFieldOrderingVisible.last, first != last else { return v }
 
             if first?.isFirstResponder == true {
                 v.nextButton.isEnabled = true
@@ -185,9 +239,9 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
         guard let inputAccesoryView  = inputAccessoryView as? NavigationAccessoryView else { return }
 
         var index = 0
-        for field in textFieldOrdering {
+        for field in textFieldOrderingVisible {
             if field?.isFirstResponder == true {
-                let _ = sender == inputAccesoryView.previousButton ? textFieldOrdering[index-1]?.becomeFirstResponder() : textFieldOrdering[index+1]?.becomeFirstResponder()
+                let _ = sender == inputAccesoryView.previousButton ? textFieldOrderingVisible[index-1]?.becomeFirstResponder() : textFieldOrderingVisible[index+1]?.becomeFirstResponder()
                 break
             }
             index += 1
@@ -358,6 +412,44 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
     open func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         return formViewController()?.textInputShouldEndEditing(textField, cell: self) ?? true
     }
+	
+	//MARK: UITableViewDataSource
+	
+	public func numberOfSections(in tableView: UITableView) -> Int {
+		guard let rowConformance = row as? PostalAddressRowConformance else{ return 0 }
+		return rowConformance.countrySelectorRow == nil ? 0 : 1
+	}
+	
+	public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		guard let rowConformance = row as? PostalAddressRowConformance else{ return 0 }
+		return rowConformance.countrySelectorRow == nil ? 0 : 1
+	}
+	
+	//MARK: UITableViewDelegate
+	
+	public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		guard let row = (row as? PostalAddressRowConformance)?.countrySelectorRow else{ fatalError() }
+		return row.baseCell
+	}
+	
+	public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		guard let row = (row as? PostalAddressRowConformance)?.countrySelectorRow else{ return }
+		
+		// row.baseCell.cellBecomeFirstResponder() may be cause InlineRow collapsed then section count will be changed. Use orignal indexPath will out of  section's bounds.
+		if !row.baseCell.cellCanBecomeFirstResponder() || !row.baseCell.cellBecomeFirstResponder() {
+			tableView.endEditing(true)
+		}
+		row.didSelect()
+	}
+	
+	public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+		guard let row = (row as? PostalAddressRowConformance)?.countrySelectorRow else{ return tableView.rowHeight }
+		return row.baseCell.height?() ?? tableView.rowHeight
+	}
+	
+	public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+		return false
+	}
 }
 
 

--- a/Sources/PostalAddressCell.swift
+++ b/Sources/PostalAddressCell.swift
@@ -123,9 +123,6 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
 				}.cellUpdate{ [weak self] cell, row in
 					cell.selectionStyle = .none
 					cell.textLabel?.textColor = self?.row.value?.country == nil ? UIColor(red: 196.0/255.0, green: 196.0/255.0, blue: 196.0/255.0, alpha: 1.0) : (self?.row.isDisabled == true ? .gray : .black)
-				
-				}.onPresent{ from, to in
-					to.sectionKeyForValue = { _ in return selectorRow.selectorTitle ?? "" }
 				}
 			
 			selectorRow.baseCell.setup()
@@ -164,7 +161,7 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
         countryTextField?.keyboardType = .asciiCapable
 
         if let rowConformance = row as? PostalAddressRowConformance {
-            setPlaceholderToTextField(textField: streetTextField, placeholder: rowConformance.streetPlaceholder)
+			setPlaceholderToTextField(textField: streetTextField, placeholder: rowConformance.streetPlaceholder)
             setPlaceholderToTextField(textField: stateTextField, placeholder: rowConformance.statePlaceholder)
             setPlaceholderToTextField(textField: postalCodeTextField, placeholder: rowConformance.postalCodePlaceholder)
             setPlaceholderToTextField(textField: cityTextField, placeholder: rowConformance.cityPlaceholder)
@@ -172,6 +169,7 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
 			
 			rowConformance.countrySelectorRow?.title = rowConformance.countrySelectorRow?.title ?? rowConformance.countryPlaceholder
 			rowConformance.countrySelectorRow?.selectorTitle = rowConformance.countrySelectorRow?.selectorTitle ?? rowConformance.countryPlaceholder
+			rowConformance.countrySelectorRow?.value = row.value?.country
         }
     }
 

--- a/Sources/PostalAddressCell.swift
+++ b/Sources/PostalAddressCell.swift
@@ -107,11 +107,10 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
 				.onChange{ [weak self] in
 					guard let this = self else{ return }
 					
-					if this.row.baseValue == nil{
-						this.row.baseValue = PostalAddress()
-					}
+					var rowValue = this.row.value ?? T()
+					rowValue.country = $0.value
+					this.row.value = rowValue
 					
-					this.row.value?.country = $0.value
 					$0.title = $0.displayValueFor?($0.value) ?? $0.noValueDisplayText ?? (this.row as? PostalAddressRowConformance)?.countryPlaceholder
 					
 					this.row.updateCell()
@@ -119,11 +118,14 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
 				}.cellSetup{ [weak self] cell, row in
 					cell.selectionStyle = .none
 					cell.detailTextLabel?.isHidden = true
-					cell.textLabel?.textColor = self?.row.value?.country == nil ? .lightGray : (self?.row.isDisabled == true ? .gray : .black)
+					cell.textLabel?.textColor = self?.row.value?.country == nil ? UIColor(red: 196.0/255.0, green: 196.0/255.0, blue: 196.0/255.0, alpha: 1.0) : (self?.row.isDisabled == true ? .gray : .black)
 					
 				}.cellUpdate{ [weak self] cell, row in
 					cell.selectionStyle = .none
-					cell.textLabel?.textColor = self?.row.value?.country == nil ? .lightGray : (self?.row.isDisabled == true ? .gray : .black)
+					cell.textLabel?.textColor = self?.row.value?.country == nil ? UIColor(red: 196.0/255.0, green: 196.0/255.0, blue: 196.0/255.0, alpha: 1.0) : (self?.row.isDisabled == true ? .gray : .black)
+				
+				}.onPresent{ from, to in
+					to.sectionKeyForValue = { _ in return selectorRow.selectorTitle ?? "" }
 				}
 			
 			selectorRow.baseCell.setup()
@@ -258,11 +260,7 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
     }
 
     @objc open func textFieldDidChange(_ textField : UITextField){
-        if row.baseValue == nil{
-            row.baseValue = PostalAddress()
-        }
-
-        guard let textValue = textField.text else {
+		guard let textValue = textField.text else {
             switch(textField){
             case let field where field == streetTextField:
                 row.value?.street = nil
@@ -317,18 +315,19 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
                 let value: AutoreleasingUnsafeMutablePointer<AnyObject?> = AutoreleasingUnsafeMutablePointer<AnyObject?>.init(UnsafeMutablePointer<T>.allocate(capacity: 1))
                 let errorDesc: AutoreleasingUnsafeMutablePointer<NSString?>? = nil
                 if formatter.getObjectValue(value, for: textValue, errorDescription: errorDesc) {
+					var rowValue = row.value ?? T()
 
                     switch(textField){
                     case let field where field == streetTextField:
-                        row.value?.street = value.pointee as? String
+                        rowValue.street = value.pointee as? String
                     case let field where field == stateTextField:
-                        row.value?.state = value.pointee as? String
+                        rowValue.state = value.pointee as? String
                     case let field where field == postalCodeTextField:
-                        row.value?.postalCode = value.pointee as? String
+                        rowValue.postalCode = value.pointee as? String
                     case let field where field == cityTextField:
-                        row.value?.city = value.pointee as? String
+                        rowValue.city = value.pointee as? String
                     case let field where field == countryTextField:
-                        row.value?.country = value.pointee as? String
+                        rowValue.country = value.pointee as? String
                     default:
                         break
                     }
@@ -341,6 +340,8 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
                         }
                         textField.selectedTextRange = textField.textRange(from: selStartPos, to: selStartPos)
                     }
+					
+					row.value = rowValue
                     return
                 }
             }
@@ -363,21 +364,23 @@ open class _PostalAddressCell<T: PostalAddressType>: Cell<T>, CellType, PostalAd
             }
             return
         }
-
+		
+		var rowValue = row.value ?? T()
         switch(textField){
         case let field where field == streetTextField:
-            row.value?.street = textValue
+            rowValue.street = textValue
         case let field where field == stateTextField:
-            row.value?.state = textValue
+            rowValue.state = textValue
         case let field where field == postalCodeTextField:
-            row.value?.postalCode = textValue
+            rowValue.postalCode = textValue
         case let field where field == cityTextField:
-            row.value?.city = textValue
+            rowValue.city = textValue
         case let field where field == countryTextField:
-            row.value?.country = textValue
+            rowValue.country = textValue
         default:
             break
         }
+		row.value = rowValue
     }
 
     //MARK: TextFieldDelegate

--- a/Sources/PostalAddressCell.xib
+++ b/Sources/PostalAddressCell.xib
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,48 +17,60 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="120"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZGc-Q2-z6J" id="WPE-jg-X35">
-                <frame key="frameInset" width="375" height="119"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="119.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o5S-WV-gmI">
+                        <rect key="frame" x="26" y="11" width="333" height="32.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zxA-BK-d42">
+                        <rect key="frame" x="0.0" y="43.5" width="375" height="1"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="TdQ-t3-lW8"/>
                         </constraints>
                     </view>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DdI-zm-cRt">
+                        <rect key="frame" x="26" y="44.5" width="107.5" height="32"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Wb4-F5-tW5">
+                        <rect key="frame" x="143.5" y="43.5" width="215.5" height="32"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WKJ-zQ-8R6">
+                        <rect key="frame" x="0.0" y="75.5" width="375" height="1"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="BdP-Sq-c1v"/>
                         </constraints>
                     </view>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pdn-aV-W4Q">
+                        <rect key="frame" x="143.5" y="76.5" width="215.5" height="32"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Lu6-hl-9pm">
+                        <rect key="frame" x="26" y="76.5" width="107.5" height="32.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
+                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rNh-KU-ipC" customClass="FormViewController">
+                        <rect key="frame" x="133.5" y="76.5" width="225.5" height="32.5"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </tableView>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="bottomMargin" secondItem="Lu6-hl-9pm" secondAttribute="bottom" id="2CL-QA-OP0"/>
                     <constraint firstItem="zxA-BK-d42" firstAttribute="top" secondItem="o5S-WV-gmI" secondAttribute="bottom" id="3m8-71-U9I"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="width" secondItem="Wb4-F5-tW5" secondAttribute="width" multiplier="0.5" id="4Q5-tS-RKi"/>
                     <constraint firstAttribute="topMargin" secondItem="o5S-WV-gmI" secondAttribute="top" id="84h-Rq-4Ai"/>
@@ -72,21 +87,26 @@
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="trailing" secondItem="o5S-WV-gmI" secondAttribute="trailing" id="M2X-vX-kJi"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="trailing" secondItem="pdn-aV-W4Q" secondAttribute="trailing" id="PJ8-45-ui0"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="trailing" secondItem="Lu6-hl-9pm" secondAttribute="trailing" id="PQD-gP-1hl"/>
+                    <constraint firstItem="rNh-KU-ipC" firstAttribute="leading" secondItem="Lu6-hl-9pm" secondAttribute="trailing" id="ZmU-AE-iXk"/>
+                    <constraint firstItem="rNh-KU-ipC" firstAttribute="top" secondItem="WKJ-zQ-8R6" secondAttribute="bottom" id="abv-SY-xi2"/>
                     <constraint firstAttribute="bottomMargin" secondItem="pdn-aV-W4Q" secondAttribute="bottom" id="duk-kE-Q1B"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="rNh-KU-ipC" secondAttribute="bottom" id="eM8-cn-1Yx"/>
+                    <constraint firstItem="Lu6-hl-9pm" firstAttribute="top" secondItem="DdI-zm-cRt" secondAttribute="bottom" id="j8e-yP-pap"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="leading" secondItem="pdn-aV-W4Q" secondAttribute="leading" id="kGf-7m-VRp"/>
                     <constraint firstItem="Lu6-hl-9pm" firstAttribute="height" secondItem="o5S-WV-gmI" secondAttribute="height" id="kPl-j6-9Di"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="height" secondItem="Lu6-hl-9pm" secondAttribute="height" id="kfN-fm-NE8"/>
                     <constraint firstItem="WKJ-zQ-8R6" firstAttribute="trailing" secondItem="zxA-BK-d42" secondAttribute="trailing" id="lNp-rP-8EN"/>
                     <constraint firstItem="pdn-aV-W4Q" firstAttribute="top" secondItem="WKJ-zQ-8R6" secondAttribute="bottom" id="lWs-vF-VD5"/>
                     <constraint firstAttribute="trailing" secondItem="zxA-BK-d42" secondAttribute="trailing" id="omM-qO-r0i"/>
+                    <constraint firstItem="rNh-KU-ipC" firstAttribute="trailing" secondItem="WPE-jg-X35" secondAttribute="trailingMargin" id="qpM-qa-7i8"/>
                     <constraint firstItem="Lu6-hl-9pm" firstAttribute="leading" secondItem="o5S-WV-gmI" secondAttribute="leading" id="r5j-iN-Cwo"/>
-                    <constraint firstItem="Lu6-hl-9pm" firstAttribute="baseline" secondItem="pdn-aV-W4Q" secondAttribute="baseline" id="t3z-eq-Rzb"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="leading" secondItem="Lu6-hl-9pm" secondAttribute="leading" id="xHp-MN-w6B"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="top" secondItem="zxA-BK-d42" secondAttribute="bottom" id="zEH-0P-Xzz"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="cityTextField" destination="Wb4-F5-tW5" id="Fby-93-VOG"/>
+                <outlet property="countrySelectorTableView" destination="rNh-KU-ipC" id="Nin-XS-IJJ"/>
                 <outlet property="countryTextField" destination="pdn-aV-W4Q" id="BcK-0Z-u14"/>
                 <outlet property="firstSeparatorView" destination="zxA-BK-d42" id="xdf-uS-cRp"/>
                 <outlet property="postalCodeTextField" destination="DdI-zm-cRt" id="vil-U6-QHL"/>

--- a/Sources/PostalAddressCell.xib
+++ b/Sources/PostalAddressCell.xib
@@ -21,87 +21,86 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="o5S-WV-gmI">
-                        <rect key="frame" x="26" y="11" width="333" height="32.5"/>
+                        <rect key="frame" x="26" y="11" width="333" height="25.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zxA-BK-d42">
-                        <rect key="frame" x="0.0" y="43.5" width="375" height="1"/>
+                        <rect key="frame" x="0.0" y="40.5" width="375" height="1"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="TdQ-t3-lW8"/>
                         </constraints>
                     </view>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DdI-zm-cRt">
-                        <rect key="frame" x="26" y="44.5" width="107.5" height="32"/>
+                        <rect key="frame" x="26" y="45.5" width="107.5" height="26.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Wb4-F5-tW5">
-                        <rect key="frame" x="143.5" y="43.5" width="215.5" height="32"/>
+                        <rect key="frame" x="143.5" y="45.5" width="215.5" height="26.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WKJ-zQ-8R6">
-                        <rect key="frame" x="0.0" y="75.5" width="375" height="1"/>
+                        <rect key="frame" x="0.0" y="76" width="375" height="1"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="BdP-Sq-c1v"/>
                         </constraints>
                     </view>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pdn-aV-W4Q">
-                        <rect key="frame" x="143.5" y="76.5" width="215.5" height="32"/>
+                        <rect key="frame" x="143.5" y="83" width="215.5" height="26"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Lu6-hl-9pm">
-                        <rect key="frame" x="26" y="76.5" width="107.5" height="32.5"/>
+                        <rect key="frame" x="26" y="85" width="107.5" height="25.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rNh-KU-ipC" customClass="FormViewController">
-                        <rect key="frame" x="133.5" y="76.5" width="225.5" height="32.5"/>
+                        <rect key="frame" x="133.5" y="77" width="241.5" height="32"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tableView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottomMargin" secondItem="Lu6-hl-9pm" secondAttribute="bottom" id="2CL-QA-OP0"/>
-                    <constraint firstItem="zxA-BK-d42" firstAttribute="top" secondItem="o5S-WV-gmI" secondAttribute="bottom" id="3m8-71-U9I"/>
+                    <constraint firstItem="zxA-BK-d42" firstAttribute="top" secondItem="o5S-WV-gmI" secondAttribute="bottom" constant="4" id="3m8-71-U9I"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="width" secondItem="Wb4-F5-tW5" secondAttribute="width" multiplier="0.5" id="4Q5-tS-RKi"/>
                     <constraint firstAttribute="topMargin" secondItem="o5S-WV-gmI" secondAttribute="top" id="84h-Rq-4Ai"/>
                     <constraint firstItem="pdn-aV-W4Q" firstAttribute="height" secondItem="DdI-zm-cRt" secondAttribute="height" id="9Fr-py-YZv"/>
-                    <constraint firstItem="pdn-aV-W4Q" firstAttribute="top" secondItem="DdI-zm-cRt" secondAttribute="bottom" id="A9R-DC-dbb"/>
                     <constraint firstItem="zxA-BK-d42" firstAttribute="leading" secondItem="WPE-jg-X35" secondAttribute="leading" id="Aly-9u-sp2"/>
                     <constraint firstItem="WKJ-zQ-8R6" firstAttribute="leading" secondItem="zxA-BK-d42" secondAttribute="leading" id="Aod-23-UKH"/>
                     <constraint firstItem="o5S-WV-gmI" firstAttribute="leading" secondItem="WPE-jg-X35" secondAttribute="leadingMargin" constant="10" id="Azs-EM-5Pr"/>
-                    <constraint firstItem="WKJ-zQ-8R6" firstAttribute="top" secondItem="Wb4-F5-tW5" secondAttribute="bottom" id="C9Z-ni-hbg"/>
+                    <constraint firstItem="WKJ-zQ-8R6" firstAttribute="top" secondItem="Wb4-F5-tW5" secondAttribute="bottom" constant="4" id="C9Z-ni-hbg"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="leading" secondItem="DdI-zm-cRt" secondAttribute="trailing" constant="10" id="HtK-0d-d5M"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="height" secondItem="DdI-zm-cRt" secondAttribute="height" id="Iir-j8-rhE"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="baseline" secondItem="DdI-zm-cRt" secondAttribute="baseline" id="Jml-yT-60Z"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Wb4-F5-tW5" secondAttribute="trailing" id="Km3-mq-aPx"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="trailing" secondItem="o5S-WV-gmI" secondAttribute="trailing" id="M2X-vX-kJi"/>
+                    <constraint firstItem="Wb4-F5-tW5" firstAttribute="top" secondItem="zxA-BK-d42" secondAttribute="bottom" constant="4" id="OsS-q5-Orm"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="trailing" secondItem="pdn-aV-W4Q" secondAttribute="trailing" id="PJ8-45-ui0"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="trailing" secondItem="Lu6-hl-9pm" secondAttribute="trailing" id="PQD-gP-1hl"/>
                     <constraint firstItem="rNh-KU-ipC" firstAttribute="leading" secondItem="Lu6-hl-9pm" secondAttribute="trailing" id="ZmU-AE-iXk"/>
                     <constraint firstItem="rNh-KU-ipC" firstAttribute="top" secondItem="WKJ-zQ-8R6" secondAttribute="bottom" id="abv-SY-xi2"/>
                     <constraint firstAttribute="bottomMargin" secondItem="pdn-aV-W4Q" secondAttribute="bottom" id="duk-kE-Q1B"/>
                     <constraint firstAttribute="bottomMargin" secondItem="rNh-KU-ipC" secondAttribute="bottom" id="eM8-cn-1Yx"/>
-                    <constraint firstItem="Lu6-hl-9pm" firstAttribute="top" secondItem="DdI-zm-cRt" secondAttribute="bottom" id="j8e-yP-pap"/>
+                    <constraint firstItem="Lu6-hl-9pm" firstAttribute="top" secondItem="WKJ-zQ-8R6" secondAttribute="bottom" constant="8" id="j8e-yP-pap"/>
                     <constraint firstItem="Wb4-F5-tW5" firstAttribute="leading" secondItem="pdn-aV-W4Q" secondAttribute="leading" id="kGf-7m-VRp"/>
                     <constraint firstItem="Lu6-hl-9pm" firstAttribute="height" secondItem="o5S-WV-gmI" secondAttribute="height" id="kPl-j6-9Di"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="height" secondItem="Lu6-hl-9pm" secondAttribute="height" id="kfN-fm-NE8"/>
                     <constraint firstItem="WKJ-zQ-8R6" firstAttribute="trailing" secondItem="zxA-BK-d42" secondAttribute="trailing" id="lNp-rP-8EN"/>
-                    <constraint firstItem="pdn-aV-W4Q" firstAttribute="top" secondItem="WKJ-zQ-8R6" secondAttribute="bottom" id="lWs-vF-VD5"/>
+                    <constraint firstItem="pdn-aV-W4Q" firstAttribute="top" secondItem="WKJ-zQ-8R6" secondAttribute="bottom" constant="6" id="lWs-vF-VD5"/>
                     <constraint firstAttribute="trailing" secondItem="zxA-BK-d42" secondAttribute="trailing" id="omM-qO-r0i"/>
-                    <constraint firstItem="rNh-KU-ipC" firstAttribute="trailing" secondItem="WPE-jg-X35" secondAttribute="trailingMargin" id="qpM-qa-7i8"/>
+                    <constraint firstItem="rNh-KU-ipC" firstAttribute="trailing" secondItem="WPE-jg-X35" secondAttribute="trailing" id="qpM-qa-7i8"/>
                     <constraint firstItem="Lu6-hl-9pm" firstAttribute="leading" secondItem="o5S-WV-gmI" secondAttribute="leading" id="r5j-iN-Cwo"/>
                     <constraint firstItem="DdI-zm-cRt" firstAttribute="leading" secondItem="Lu6-hl-9pm" secondAttribute="leading" id="xHp-MN-w6B"/>
-                    <constraint firstItem="DdI-zm-cRt" firstAttribute="top" secondItem="zxA-BK-d42" secondAttribute="bottom" id="zEH-0P-Xzz"/>
+                    <constraint firstItem="DdI-zm-cRt" firstAttribute="top" secondItem="zxA-BK-d42" secondAttribute="bottom" constant="4" id="zEH-0P-Xzz"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/Sources/PostalAddressRow.swift
+++ b/Sources/PostalAddressRow.swift
@@ -70,11 +70,20 @@ public protocol PostalAddressRowConformance: PostalAddressFormatterConformance {
     var postalCodePlaceholder : String? { get set }
     var cityPlaceholder : String? { get set }
     var countryPlaceholder : String? { get set }
+	var countrySelectorRow : PushRow<String>?{ get set }
 }
 
 //MARK: PostalAddressRow
 
 open class _PostalAddressRow<Cell: CellType>: Row<Cell>, PostalAddressRowConformance, KeyboardReturnHandler where Cell: BaseCell, Cell: PostalAddressCellConformance {
+	
+	open override var section: Section?{
+		get{ return super.section }
+		set{
+			countrySelectorRow?.section = newValue
+			super.section = newValue
+		}
+	}
     
     /// Configuration for the keyboardReturnType of this row
     open var keyboardReturnType : KeyboardReturnTypeConfiguration?
@@ -129,6 +138,9 @@ open class _PostalAddressRow<Cell: CellType>: Row<Cell>, PostalAddressRowConform
     
     /// If the formatter should be used while the user is editing the country.
     open var countryUseFormatterDuringInput: Bool
+	
+	/// the country selector row
+	open var countrySelectorRow: PushRow<String>?
     
     public required init(tag: String?) {
         streetUseFormatterDuringInput = false
@@ -139,6 +151,11 @@ open class _PostalAddressRow<Cell: CellType>: Row<Cell>, PostalAddressRowConform
         
         super.init(tag: tag)
     }
+	
+	open override func updateCell(){
+		super.updateCell()
+		countrySelectorRow?.updateCell()
+	}
 }
 
 /// A PostalAddress valued row where the user can enter a postal address.

--- a/Sources/PostalAddressRow.swift
+++ b/Sources/PostalAddressRow.swift
@@ -80,10 +80,13 @@ public protocol PostalAddressRowConformance: PostalAddressFormatterConformance {
 open class _PostalAddressRow<Cell: CellType>: Row<Cell>, PostalAddressRowConformance, KeyboardReturnHandler where Cell: BaseCell, Cell: PostalAddressCellConformance {
 	
 	open override var section: Section?{
-		get{ return super.section }
-		set{
-			countrySelectorRow?.section = newValue
-			super.section = newValue
+		didSet{
+			guard let section = section, let row = countrySelectorRow else { return }
+			let rowValue = row.value
+			row.value = nil
+			
+			row.section = section
+			row.value = rowValue //triggers the onChange event
 		}
 	}
     
@@ -162,6 +165,15 @@ open class _PostalAddressRow<Cell: CellType>: Row<Cell>, PostalAddressRowConform
 
 /// A PostalAddress valued row where the user can enter a postal address.
 public final class PostalAddressRow: _PostalAddressRow<PostalAddressCell>, RowType {
+	
+	open override var value: Cell.Value?{
+		get{ return super.value }
+		set{
+			self.countrySelectorRow?.value = newValue?.country
+			super.value = newValue
+		}
+	}
+	
     public required init(tag: String? = nil) {
         super.init(tag: tag)
         // load correct bundle for cell nib file

--- a/Sources/PostalAddressRow.swift
+++ b/Sources/PostalAddressRow.swift
@@ -20,6 +20,8 @@ public protocol PostalAddressType: Equatable {
     var postalCode: String? { get set }
     var city: String? { get set }
     var country: String? { get set }
+	
+	init()
 }
 
 public func == <T: PostalAddressType>(lhs: T, rhs: T) -> Bool {


### PR DESCRIPTION
This pull request adds the ability to define a country selector using the newly added `var countrySelectorRow : PushRow<String>?` as discussed in https://github.com/EurekaCommunity/PostalAddressRow/issues/3.

To make use of this you'll define a `PostalAddressRow` like this (see the Example project):

```
<<< PostalAddressRow() {
	$0.streetPlaceholder = "Street"
	$0.statePlaceholder = "State"
	$0.cityPlaceholder = "City"
	$0.countryPlaceholder = "Country"
	$0.postalCodePlaceholder = "Zip code"
	
	$0.countrySelectorRow = PushRow<String>(){
		$0.options = ["GB","US"]
		$0.displayValueFor = { guard let isoCode = $0 else{ return nil }
			return Locale.current.localizedString(forRegionCode: isoCode)
		}
	}
}
```

If you want to use custom Nibs, you'll have to add a `UITableView` linked with `@IBOutlet open var countrySelectorTableView: UITableView?`.

And this is how it looks like:

![picker](https://user-images.githubusercontent.com/392542/34622234-abc62d88-f24c-11e7-9dc5-aceddd67d8c7.png)
![detail](https://user-images.githubusercontent.com/392542/34622237-aefdde2e-f24c-11e7-809c-d79b6f8f75bf.png)
